### PR TITLE
Minor fixes

### DIFF
--- a/components/program_manager/db/migrate/20210705215515_create_cards.rb
+++ b/components/program_manager/db/migrate/20210705215515_create_cards.rb
@@ -3,7 +3,6 @@
 class CreateCards < ActiveRecord::Migration[5.2]
   def change
     create_table :program_manager_cards do |t|
-      t.bigint :customer_id
       t.string :number
 
       t.timestamps

--- a/components/program_manager/db/migrate/20210705215515_create_cards.rb
+++ b/components/program_manager/db/migrate/20210705215515_create_cards.rb
@@ -3,6 +3,7 @@
 class CreateCards < ActiveRecord::Migration[5.2]
   def change
     create_table :program_manager_cards do |t|
+      t.bigint :customer_id
       t.string :number
 
       t.timestamps

--- a/components/program_manager/db/migrate/20210705215516_create_transactions.rb
+++ b/components/program_manager/db/migrate/20210705215516_create_transactions.rb
@@ -3,7 +3,6 @@
 class CreateTransactions < ActiveRecord::Migration[5.2]
   def change
     create_table :program_manager_transactions do |t|
-      t.bigint :customer_id
       t.bigint :parent_transaction_id
       t.bigint :card_id, limit: 36, null: false
       t.string :transaction_type, null: false

--- a/components/program_manager/db/migrate/20210705215516_create_transactions.rb
+++ b/components/program_manager/db/migrate/20210705215516_create_transactions.rb
@@ -6,7 +6,7 @@ class CreateTransactions < ActiveRecord::Migration[5.2]
       t.bigint :customer_id
       t.bigint :parent_transaction_id
       t.bigint :card_id, limit: 36, null: false
-      t.string :type, null: false
+      t.string :transaction_type, null: false
       t.string :currency, limit: 3, null: false
       t.integer :amount
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,6 +16,7 @@ ActiveRecord::Schema.define(version: 2021_07_05_215516) do
   enable_extension "plpgsql"
 
   create_table "program_manager_cards", force: :cascade do |t|
+    t.bigint "customer_id"
     t.string "number"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -29,7 +30,6 @@ ActiveRecord::Schema.define(version: 2021_07_05_215516) do
   end
 
   create_table "program_manager_transactions", force: :cascade do |t|
-    t.bigint "customer_id"
     t.bigint "parent_transaction_id"
     t.bigint "card_id", null: false
     t.string "transaction_type", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,7 +16,6 @@ ActiveRecord::Schema.define(version: 2021_07_05_215516) do
   enable_extension "plpgsql"
 
   create_table "program_manager_cards", force: :cascade do |t|
-    t.bigint "customer_id"
     t.string "number"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -33,7 +32,7 @@ ActiveRecord::Schema.define(version: 2021_07_05_215516) do
     t.bigint "customer_id"
     t.bigint "parent_transaction_id"
     t.bigint "card_id", null: false
-    t.string "type", null: false
+    t.string "transaction_type", null: false
     t.string "currency", limit: 3, null: false
     t.integer "amount"
     t.datetime "created_at", null: false


### PR DESCRIPTION
- Rename `type` column to `transaction_type` in `transactions` table.
- A transaction doesn't belong to a customer, a transaction belongs to a card and the card belongs to a customer.